### PR TITLE
National Flood Hazard Layer

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,15 @@
 History
 =======
 
+0.15.3 (2023-XX-XX)
+-------------------
+
+New Features
+~~~~~~~~~~~~
+- Add ``NFHL`` class within ``nfhl.py`` module to access FEMA's
+  National Flood Hazard Layer (NFHL) using six different ArcGISRESTFul
+  services.
+
 0.15.2 (2023-0X-XX)
 -------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,15 +2,6 @@
 History
 =======
 
-0.15.3 (2023-XX-XX)
--------------------
-
-New Features
-~~~~~~~~~~~~
-- Add ``NFHL`` class within ``nfhl.py`` module to access FEMA's
-  National Flood Hazard Layer (NFHL) using six different ArcGISRESTFul
-  services.
-
 0.15.2 (2023-0X-XX)
 -------------------
 
@@ -19,6 +10,9 @@ New Features
 - Add a new attribute to ``EHydro`` class called ``survey_grid``.
   It's a ``geopandas.GeoDataFrame`` that includes the survey grid
   of the eHydro dataset which is a 35-km hexagonal grid.
+- Add ``NFHL`` class within ``nfhl.py`` module to access FEMA's
+  National Flood Hazard Layer (NFHL) using six different ArcGISRESTFul
+  services.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -452,6 +452,18 @@ get the two Hudson HUC4s:
     wbd = WBD("huc4")
     hudson = wbd.byids("huc4", ["0202", "0203"])
 
+
+The ``NFHL`` class allows us to retrieve FEMA's National Flood Hazard Layer (NFHL) data.
+Let's get the cross-section data for a small region in Vermont:
+
+.. code-block:: python
+
+    from pygeohydro import NFHL
+
+    nfhl = NFHL("NFHL", "cross-sections")
+    gdf_xs = nfhl.bygeom((-73.42, 43.28, -72.9, 43.52), geo_crs="epsg:4269")
+
+
 Contributing
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,8 @@ PyGeoHydro supports the following datasets:
 * `STN <https://stn.wim.usgs.gov/STNWeb/#/>`__ for access USGS Short-Term Network (STN)
 * `eHydro <https://navigation.usace.army.mil/Survey/Hydro>`__ for accessing USACE
   Hydrographic Surveys that includes topobathymetry data
+* `NFHL <https://hazards.fema.gov/femaportal/wps/portal/NFHLWMS>`__ for accessing
+  FEMA's National Flood Hazard Layer (NFHL) data.
 
 Also, it includes several other functions:
 

--- a/pygeohydro/__init__.py
+++ b/pygeohydro/__init__.py
@@ -15,6 +15,7 @@ from pygeohydro.exceptions import (
     ZeroMatchedError,
 )
 from pygeohydro.helpers import get_us_states
+from pygeohydro.nfhl import NFHL
 from pygeohydro.nlcd import (
     cover_statistics,
     nlcd_area_percent,
@@ -48,6 +49,7 @@ __all__ = [
     "NID",
     "WBD",
     "NWIS",
+    "NFHL",
     "WaterQuality",
     "streamflow_fillna",
     "cover_statistics",

--- a/pygeohydro/nfhl.py
+++ b/pygeohydro/nfhl.py
@@ -96,15 +96,3 @@ class NFHL(AGRBase):
             raise InputValueError("service", list(self.valid_services))
 
         super().__init__(url, layer, outfields, crs)
-
-    """
-    # TODO: Will remove once pygeoogc is updated.
-    valid_services = {
-        "NFHL": ServiceURL().restful.fema,
-        "Prelim_CSLF": "https://hazards.fema.gov/gis/nfhl/rest/services/CSLF/Prelim_CSLF/MapServer",
-        "Draft_CSLF": "https://hazards.fema.gov/gis/nfhl/rest/services/CSLF/Draft_CSLF/MapServer",
-        "Prelim_NFHL": "https://hazards.fema.gov/gis/nfhl/rest/services/PrelimPending/Prelim_NFHL/MapServer",
-        "Pending_NFHL": "https://hazards.fema.gov/gis/nfhl/rest/services/PrelimPending/Pending_NFHL/MapServer",
-        "Draft_NFHL": "https://hazards.fema.gov/gis/nfhl/rest/services/AFHI/Draft_FIRM_DB/MapServer",
-    }
-    """

--- a/pygeohydro/nfhl.py
+++ b/pygeohydro/nfhl.py
@@ -19,10 +19,34 @@ class NFHL(AGRBase):
     """
     Access National Flood Hazard Layers (NFHL).
 
+    Attributes
+    ----------
+    valid_services : Dict
+        A dictionary of valid services and their URLs.
+
+    Methods
+    -------
+    bygeom(geom, geo_crs=4326, sql_clause="", distance=None, return_m=False, return_geom=True)
+        Get features within a geometry that can be combined with a SQL where clause.
+    byids(field, fids, return_m=False, return_geom=True)
+        Get features by object IDs.
+    bysql(sql_clause, return_m=False, return_geom=True)
+        Get features using a valid SQL 92 WHERE clause.
+
     References
     ----------
     * `National Flood Hazard Layer GIS Web Services` <https://hazards.fema.gov/femaportal/wps/portal/NFHLWMS>
     """
+
+    # service URLs
+    valid_services = {
+        "NFHL": ServiceURL().restful.fema_nfhl,
+        "Prelim_CSLF": ServiceURL().restful.fema_prelim_cslf,
+        "Draft_CSLF": ServiceURL().restful.fema_draft_cslf,
+        "Prelim_NFHL": ServiceURL().restful.fema_prelim_nfhl,
+        "Pending_NFHL": ServiceURL().restful.fema_pending_nfhl,
+        "Draft_NFHL": ServiceURL().restful.fema_draft_nfhl,
+    }
 
     def __init__(
         self, service: str, layer: str, outfields: str | list[str] = "*", crs: CRSTYPE = 4326
@@ -67,31 +91,20 @@ class NFHL(AGRBase):
         ----------
         * `National Flood Hazard Layer GIS Web Services` <https://hazards.fema.gov/femaportal/wps/portal/NFHLWMS>
         """
-        """
-        NOTE: Will replace below once pygeoogc is updated.
-        self.valid_services = {
-            "NFHL": ServiceURL().restful.fema,
-            "Prelim_CSLF": ServiceURL().restful.fema_prelim_cslf,
-            "Draft_CSLF": ServiceURL().restful.fema_draft_cslf,
-            "Prelim_NFHL": ServiceURL().restful.fema_prelim_nfhl,
-            "Pending_NFHL": ServiceURL().restful.fema_pending_nfhl,
-            "Draft_NFHL": ServiceURL().restful.fema_draft_nfhl
-        }
-        """
-
-        # NOTE: Temporary URLs until pygeoogc is updated.
-        self.valid_services = {
-            "NFHL": ServiceURL().restful.fema,
-            "Prelim_CSLF": "https://hazards.fema.gov/gis/nfhl/rest/services/CSLF/Prelim_CSLF/MapServer",
-            "Draft_CSLF": "https://hazards.fema.gov/gis/nfhl/rest/services/CSLF/Draft_CSLF/MapServer",
-            "Prelim_NFHL": "https://hazards.fema.gov/gis/nfhl/rest/services/PrelimPending/Prelim_NFHL/MapServer",
-            "Pending_NFHL": "https://hazards.fema.gov/gis/nfhl/rest/services/PrelimPending/Pending_NFHL/MapServer",
-            "Draft_NFHL": "https://hazards.fema.gov/gis/nfhl/rest/services/AFHI/Draft_FIRM_DB/MapServer",
-        }
-
         url = self.valid_services.get(service)
         if url is None:
             raise InputValueError("service", list(self.valid_services))
 
-        _layer = layer
-        super().__init__(url, _layer, outfields, crs)
+        super().__init__(url, layer, outfields, crs)
+
+    """
+    # TODO: Will remove once pygeoogc is updated.
+    valid_services = {
+        "NFHL": ServiceURL().restful.fema,
+        "Prelim_CSLF": "https://hazards.fema.gov/gis/nfhl/rest/services/CSLF/Prelim_CSLF/MapServer",
+        "Draft_CSLF": "https://hazards.fema.gov/gis/nfhl/rest/services/CSLF/Draft_CSLF/MapServer",
+        "Prelim_NFHL": "https://hazards.fema.gov/gis/nfhl/rest/services/PrelimPending/Prelim_NFHL/MapServer",
+        "Pending_NFHL": "https://hazards.fema.gov/gis/nfhl/rest/services/PrelimPending/Pending_NFHL/MapServer",
+        "Draft_NFHL": "https://hazards.fema.gov/gis/nfhl/rest/services/AFHI/Draft_FIRM_DB/MapServer",
+    }
+    """

--- a/pygeohydro/nfhl.py
+++ b/pygeohydro/nfhl.py
@@ -39,6 +39,7 @@ class NFHL(AGRBase):
             - ``Prelim_CSLF``: Preliminary Changes Since Last Firm (CSLF)
             - ``Draft_CSLF``: Draft Changes Since Last Firm (CSLF)
             - ``Prelim_NFHL``: Preliminary National Flood Hazard Layers
+            - ``Pending_NFHL``: Pending National Flood Hazard Layers
             - ``Draft_NFHL``: Draft National Flood Hazard Layers
 
         layer : str

--- a/pygeohydro/nfhl.py
+++ b/pygeohydro/nfhl.py
@@ -1,0 +1,96 @@
+"""Accessing National Flood Hazard Layers (NFHL) through web services."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union
+
+import pyproj
+
+from pygeohydro.exceptions import InputValueError
+from pygeoogc import ServiceURL
+from pynhd import AGRBase
+
+if TYPE_CHECKING:
+    CRSTYPE = Union[int, str, pyproj.CRS]
+
+__all__ = ["NFHL"]
+
+
+class NFHL(AGRBase):
+    """
+    Access National Flood Hazard Layers (NFHL).
+
+    References
+    ----------
+    * `National Flood Hazard Layer GIS Web Services` <https://hazards.fema.gov/femaportal/wps/portal/NFHLWMS>
+    """
+
+    def __init__(
+        self, service: str, layer: str, outfields: str | list[str] = "*", crs: CRSTYPE = 4326
+    ):
+        """
+        Access National Flood Hazard Layers (NFHL).
+
+        Parameters
+        ----------
+        service : str
+            The service type. Valid services are:
+
+            - ``NFHL``: Effective National Flood Hazard Layers
+            - ``Prelim_CSLF``: Preliminary Changes Since Last Firm (CSLF)
+            - ``Draft_CSLF``: Draft Changes Since Last Firm (CSLF)
+            - ``Prelim_NFHL``: Preliminary National Flood Hazard Layers
+            - ``Draft_NFHL``: Draft National Flood Hazard Layers
+
+        layer : str
+            A valid service layer. Valid layers are service specific:
+
+            - ``NFHL``: ``nfhl availability``, ``firm panels``, ``lomrs``, ``lomas``, ``political jurisdictions``, ``profile baselines``, ``water lines``, ``cross-sections``, ``base flood elevations``, ``levees``, ``seclusion boundaries``, ``coastal transects``, ``transect baselines``, ``general structures``, ``river mile markers``, ``water areas``, ``plss``, ``limit of moderate wave action``, ``flood hazard boundaries``, ``flood hazard zones``, ``primary frontal dunes``, ``base index``, ``topographic low confidence areas``, ``datum conversion points``, ``coastal gages``, ``gages``, ``nodes``, ``high water marks``, ``station start points``, ``hydrologic reaches``, ``alluvial fans``, ``subbasins``
+            - ``Prelim_CSLF``: ``preliminary``, ``coastal high hazard area change``, ``floodway change``, ``special flood hazard area change``, ``non-special flood hazard area change``
+            - ``Draft_CSLF``: ``draft``, ``coastal high hazard area change``, ``floodway change``, ``special flood hazard area change``, ``non-special flood hazard area change``
+            - ``Prelim_NFHL``: ``preliminary data availability``, ``preliminary firm panel index``, ``preliminary plss``, ``preliminary topographic low confidence areas``, ``preliminary river mile markers``, ``preliminary datum conversion points``, ``preliminary coastal gages``, ``preliminary gages``, ``preliminary nodes``, ``preliminary high water marks``, ``preliminary station start points``, ``preliminary cross-sections``, ``preliminary coastal transects``, ``preliminary base flood elevations``, ``preliminary profile baselines``, ``preliminary transect baselines``, ``preliminary limit of moderate wave action``, ``preliminary water lines``, ``preliminary political jurisdictions``, ``preliminary levees``, ``preliminary general structures``, ``preliminary primary frontal dunes``, ``preliminary hydrologic reaches``, ``preliminary flood hazard boundaries``, ``preliminary flood hazard zones``, ``preliminary submittal information``, ``preliminary alluvial fans``, ``preliminary subbasins``, ``preliminary water areas``
+            - ``Pending_NFHL``: ``pending submittal information``, ``pending water areas``, ``pending firm panel index``, ``pending data availability``, ``pending firm panels``, ``pending political jurisdictions``, ``pending profile baselines``, ``pending water lines``, ``pending cross-sections``, ``pending base flood elevations``, ``pending levees``, ``pending seclusion boundaries``, ``pending coastal transects``, ``pending transect baselines``, ``pending general structures``, ``pending river mile markers``, ``pending plss``, ``pending limit of moderate wave action``, ``pending flood hazard boundaries``, ``pending flood hazard zones``, ``pending primary frontal dunes``, ``pending topographic low confidence areas``, ``pending datum conversion points``, ``pending coastal gages``, ``pending gages``, ``pending nodes``, ``pending high water marks``, ``pending station start points``, ``pending hydrologic reaches``, ``pending alluvial fans``, ``pending subbasins``
+            - ``Draft_NFHL``: ``draft data availability``, ``draft firm panels``, ``draft political jurisdictions``, ``draft profile baselines``, ``draft water lines``, ``draft cross-sections``, ``draft base flood elevations``, ``draft levees``, ``draft submittal info``, ``draft coastal transects``, ``draft transect baselines``, ``draft general structures``, ``draft limit of moderate wave action``, ``draft flood hazard boundaries``, ``draft flood hazard zones``
+
+        outfields : str or list, optional
+            Target field name(s), default to "*" i.e., all the fields.
+        crs : str, int, or pyproj.CRS, optional
+            Target spatial reference of output, default to ``EPSG:4326``.
+
+        Examples
+        --------
+        >>> from pygeohydro import NFHL
+        >>> nfhl = NFHL("NFHL", "cross-sections")
+        >>> gdf_xs = nfhl.bygeom((-73.42, 43.28, -72.9, 43.52), geo_crs="epsg:4269")
+
+        References
+        ----------
+        * `National Flood Hazard Layer GIS Web Services` <https://hazards.fema.gov/femaportal/wps/portal/NFHLWMS>
+        """
+        """
+        NOTE: Will replace below once pygeoogc is updated.
+        self.valid_services = {
+            "NFHL": ServiceURL().restful.fema,
+            "Prelim_CSLF": ServiceURL().restful.fema_prelim_cslf,
+            "Draft_CSLF": ServiceURL().restful.fema_draft_cslf,
+            "Prelim_NFHL": ServiceURL().restful.fema_prelim_nfhl,
+            "Pending_NFHL": ServiceURL().restful.fema_pending_nfhl,
+            "Draft_NFHL": ServiceURL().restful.fema_draft_nfhl
+        }
+        """
+
+        # NOTE: Temporary URLs until pygeoogc is updated.
+        self.valid_services = {
+            "NFHL": ServiceURL().restful.fema,
+            "Prelim_CSLF": "https://hazards.fema.gov/gis/nfhl/rest/services/CSLF/Prelim_CSLF/MapServer",
+            "Draft_CSLF": "https://hazards.fema.gov/gis/nfhl/rest/services/CSLF/Draft_CSLF/MapServer",
+            "Prelim_NFHL": "https://hazards.fema.gov/gis/nfhl/rest/services/PrelimPending/Prelim_NFHL/MapServer",
+            "Pending_NFHL": "https://hazards.fema.gov/gis/nfhl/rest/services/PrelimPending/Pending_NFHL/MapServer",
+            "Draft_NFHL": "https://hazards.fema.gov/gis/nfhl/rest/services/AFHI/Draft_FIRM_DB/MapServer",
+        }
+
+        url = self.valid_services.get(service)
+        if url is None:
+            raise InputValueError("service", list(self.valid_services))
+
+        _layer = layer
+        super().__init__(url, _layer, outfields, crs)

--- a/tests/test_pygeohydro.py
+++ b/tests/test_pygeohydro.py
@@ -12,11 +12,9 @@ from pyproj.exceptions import CRSError
 from shapely.geometry import Polygon
 
 import pygeohydro as gh
+import pynhd as nhd
 from pygeohydro import NFHL, NID, NWIS, WBD, EHydro
-from pygeohydro.exceptions import InputValueError as InputValueError_pygeohydro
 from pygeoogc import utils as ogc_utils
-from pynhd.core import ServiceInfo
-from pynhd.exceptions import InputValueError as InputValueError_pynhd
 
 DEF_CRS = 4326
 ALT_CRS = 3542
@@ -971,18 +969,18 @@ class TestNFHL:
     def test_nfhl(self, service, layer, expected_url, expected_layer):
         """Test the NFHL class."""
         nfhl = NFHL(service, layer)
-        assert isinstance(nfhl.service_info, ServiceInfo)
+        assert isinstance(nfhl.service_info, nhd.ServiceInfo)
         assert nfhl.service_info.url == expected_url
         assert nfhl.service_info.layer == expected_layer
 
     def test_nfhl_fail_layer(self):
         """Test the layer argument failures in NFHL init."""
-        with pytest.raises(InputValueError_pynhd):
+        with pytest.raises(nhd.exceptions.InputValueError):
             NFHL("NFHL", "cross_sections")
 
     def test_nfhl_fail_service(self):
         """Test the service argument failures in NFHL init."""
-        with pytest.raises(InputValueError_pygeohydro):
+        with pytest.raises(gh.exceptions.InputValueError):
             NFHL("NTHL", "cross-sections")
 
     @pytest.mark.parametrize(

--- a/tests/test_pygeohydro.py
+++ b/tests/test_pygeohydro.py
@@ -969,7 +969,7 @@ class TestNFHL:
     def test_nfhl(self, service, layer, expected_url, expected_layer):
         """Test the NFHL class."""
         nfhl = NFHL(service, layer)
-        assert isinstance(nfhl.service_info, nhd.ServiceInfo)
+        assert isinstance(nfhl.service_info, nhd.core.ServiceInfo)
         assert nfhl.service_info.url == expected_url
         assert nfhl.service_info.layer == expected_layer
 

--- a/tests/test_pygeohydro.py
+++ b/tests/test_pygeohydro.py
@@ -191,8 +191,8 @@ class TestNID:
         assert (dams_geo.name == name).any() and (dams_box.name == "Pingree Pond").any()
 
     def test_nation(self):
-        assert self.nid.df.shape == (91807, 79)
-        assert self.nid.gdf.shape == (91658, 97)
+        assert self.nid.df.shape == (91753, 77)
+        assert self.nid.gdf.shape == (91624, 95)
 
 
 class TestWaterQuality:
@@ -525,6 +525,7 @@ class TestSTNFloodEventData:
             "zone",
             "height_above_gnd",
             "is_hag_estimated",
+            "aep_upperci",
             "geometry",
         ],
         "hwms": [
@@ -985,14 +986,43 @@ class TestNFHL:
             NFHL("NTHL", "cross-sections")
 
     @pytest.mark.parametrize(
-        "service, layer, geom, expected_gdf_len",
+        "service, layer, geom, expected_gdf_len, expected_schema",
         [
-            ("NFHL", "cross-sections", (-73.42, 43.28, -72.9, 43.52), 165),
+            (
+                "NFHL",
+                "cross-sections",
+                (-73.42, 43.48, -72.5, 43.52),
+                44,
+                [
+                    "geometry",
+                    "OBJECTID",
+                    "DFIRM_ID",
+                    "VERSION_ID",
+                    "XS_LN_ID",
+                    "WTR_NM",
+                    "STREAM_STN",
+                    "START_ID",
+                    "XS_LTR",
+                    "XS_LN_TYP",
+                    "WSEL_REG",
+                    "STRMBED_EL",
+                    "LEN_UNIT",
+                    "V_DATUM",
+                    "PROFXS_TXT",
+                    "MODEL_ID",
+                    "SEQ",
+                    "SOURCE_CIT",
+                    "SHAPE.STLength()",
+                    "GFID",
+                    "GlobalID",
+                ],
+            ),
         ],
     )
-    def test_nfhl_getgeom(self, service, layer, geom, expected_gdf_len):
+    def test_nfhl_getgeom(self, service, layer, geom, expected_gdf_len, expected_schema):
         """Test the NFHL bygeom method."""
         nfhl = NFHL(service, layer)
         gdf_xs = nfhl.bygeom(geom, geo_crs="epsg:4269")
         assert isinstance(gdf_xs, gpd.GeoDataFrame)
         assert len(gdf_xs) >= expected_gdf_len
+        assert set(gdf_xs.columns) == set(expected_schema)


### PR DESCRIPTION
The following is a draft/WIP PR that adds support for FEMA's National Flood Hazard Layer via their [ArcGISRestful APIs](https://hazards.fema.gov/femaportal/wps/portal/NFHLWMS). I selected the ArcGIS services in favor of the WFS or WMS options due to greater optionality and reliability. Please see some of the issues with WFS and WMS observed below.

# Example Usage

```
from pygeohydro import NFHL
nfhl = NFHL("NFHL", "cross-sections")
gdf_xs = nfhl.bygeom((-73.42, 43.28, -72.9, 43.52), geo_crs="epsg:4269")
gdf_xs.explore()
```
![Screenshot 2023-09-18 at 11 21 27](https://github.com/hyriver/pygeohydro/assets/16439785/9e6e6e2d-9077-4fd5-bcc0-fc83edcb7406)

# Issues

## WFS

### [PyGeoOGC: Retrieve Data from RESTful, WMS, and WFS Services](https://docs.hyriver.io/readme/pygeoogc.html) Notebook

```
basin_geom = NLDI().get_basins("01031500").geometry[0]

wfs = WFS(
    ServiceURL().wfs.fema,
    layer="public_NFHL:Base_Flood_Elevations",
    outformat="esrigeojson",
    crs="epsg:4269",
)
r = wfs.getfeature_bybox(basin_geom.bounds, box_crs="epsg:4326")
flood = geoutils.json2geodf(r.json(), "epsg:4269", "epsg:4326")
```

yields the following error:

```
555 if self.layer:
    556     if self.layer not in self.available_layer:
--> 557         raise InputValueError("layers", self.available_layer)
    558     layers = [self.layer]
    559 else:

InputValueError: Given layers is invalid. Valid options are:
NFHL:NFHL_Availability
NFHL:FIRM_Panels
NFHL:LOMRs
NFHL:LOMAs
NFHL:Political_Jurisdictions
NFHL:Profile_Baselines
NFHL:Water_Lines
NFHL:Cross-Sections
NFHL:Base_Flood_Elevations
...
```

changing layer parameter to `"NFHL:Base_Flood_Elevations"` yields:

```
    535 payload = {
    536     "service": "wfs",
    537     "version": self.version,
   (...)
    543     "resultType": "hits",
    544 }
    545 resp = ar.retrieve_text([self.url], [{"params": payload}])
--> 546 nfeatures = int(resp[0].split(self.nfeat_key)[-1].split(" ")[0].strip('"'))
    548 payloads = [
    549     {
    550         "service": "wfs",
   (...)
    559     for i in range(0, nfeatures, self.max_nrecords)
    560 ]
    562 return self.retrieve([self.url] * len(payloads), [{"params": p} for p in payloads])

ValueError: invalid literal for int() with base 10: '\n<ExceptionReport\n'
```

### [PyGeoUtils: Utilities for (Geo)JSON and (Geo)TIFF Conversion](https://docs.hyriver.io/readme/pygeoutils.html) Notebook

```
geometry = Polygon(
    [
        [-118.72, 34.118],
        [-118.31, 34.118],
        [-118.31, 34.518],
        [-118.72, 34.518],
        [-118.72, 34.118],
    ]
)
crs = "epsg:4326"

url_wfs = "https://hazards.fema.gov/gis/nfhl/services/public/NFHL/MapServer/WFSServer"
wfs = WFS(
    url_wfs,
    #layer="public_NFHL:Base_Flood_Elevations",
    layer="NFHL:Base_Flood_Elevations",
    outformat="esrigeojson",
    crs="epsg:4269",
)

r = wfs.getfeature_bybox(geometry.bounds, box_crs=crs)
flood = geoutils.json2geodf(r.json(), "epsg:4269", crs)
```

yields: 

```
    545 resp = ar.retrieve_text([self.url], [{"params": payload}])
--> 546 nfeatures = int(resp[0].split(self.nfeat_key)[-1].split(" ")[0].strip('"'))
    548 payloads = [
    549     {
    550         "service": "wfs",
...
    559     for i in range(0, nfeatures, self.max_nrecords)
    560 ]
    562 return self.retrieve([self.url] * len(payloads), [{"params": p} for p in payloads])

ValueError: invalid literal for int() with base 10: '\n<ExceptionReport\n'
```

## WMS

Trying WMS gives this issue:

```
wms = WMS(
    "https://hazards.fema.gov/gis/nfhl/rest/services/public/NFHLWMS/MapServer/WMSServer",
    layers="0",
    outformat="image/png",
    crs="epsg:4269",
)
    
    
fema_dict = wms.getmap_bybox((-73.42, 43.28, -72.9, 43.52), 1e3, box_crs="epsg:4269")
```

```
      File src/lxml/etree.pyx:3257 in lxml.etree.fromstring

  File src/lxml/parser.pxi:1916 in lxml.etree._parseMemoryDocument

  File src/lxml/parser.pxi:1803 in lxml.etree._parseDoc

  File src/lxml/parser.pxi:1144 in lxml.etree._BaseParser._parseDoc

  File src/lxml/parser.pxi:618 in lxml.etree._ParserContext._handleParseResultDoc

  File src/lxml/parser.pxi:728 in lxml.etree._handleParseResult

  File src/lxml/parser.pxi:657 in lxml.etree._raiseParseError

  File <string>:42
XMLSyntaxError: EntityRef: expecting ';', line 42, column 122
```

## Note
*Connecting to both the WFS and WMS via QGIS both resolve in issues as well so this may not be HyRiver specific.*

# To-Do
- Update `pygeoogc` with additional ServiceURLs.

 - [X] Tests added and `nox` passes.
 - [X] Passes `pre-commit run --all-files`
 - [X] Changes and the contributor name are documented in `HISTORY.rst`.
